### PR TITLE
Add custom MySQL database type for Flyway

### DIFF
--- a/spring-cloud-dataflow-common-flyway/pom.xml
+++ b/spring-cloud-dataflow-common-flyway/pom.xml
@@ -13,6 +13,10 @@
 		<version>2.10.0-SNAPSHOT</version>
 	</parent>
 
+	<properties>
+		<flyway.version>8.5.11</flyway.version> <!-- have to repeat this here in order for filtering in src/main/resources/ -->
+	</properties>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework</groupId>
@@ -37,4 +41,12 @@
 		</dependency>
 	</dependencies>
 
+	<build>
+		<resources>
+			<resource>
+				<directory>src/main/resources</directory>
+				<filtering>true</filtering>
+			</resource>
+		</resources>
+	</build>
 </project>

--- a/spring-cloud-dataflow-common-flyway/src/main/java/org/flywaydb/database/mysql/MySQL57Database.java
+++ b/spring-cloud-dataflow-common-flyway/src/main/java/org/flywaydb/database/mysql/MySQL57Database.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2022-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.database.mysql;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import org.flywaydb.core.api.MigrationVersion;
+import org.flywaydb.core.api.configuration.Configuration;
+import org.flywaydb.core.internal.database.base.Database;
+import org.flywaydb.core.internal.database.base.Table;
+import org.flywaydb.core.internal.jdbc.JdbcConnectionFactory;
+import org.flywaydb.core.internal.jdbc.StatementInterceptor;
+import org.flywaydb.database.mysql.MySQLConnection;
+import org.flywaydb.database.mysql.MySQLDatabase;
+import org.flywaydb.database.mysql.mariadb.MariaDBDatabaseType;
+
+public class MySQL57Database extends Database<MySQLConnection> {
+
+    private final MySQLDatabase delegateDatabase;
+
+    public MySQL57Database(Configuration configuration, JdbcConnectionFactory jdbcConnectionFactory, StatementInterceptor statementInterceptor) {
+        this(configuration, jdbcConnectionFactory, statementInterceptor, new MySQLDatabase(configuration, jdbcConnectionFactory, statementInterceptor));
+    }
+
+    protected MySQL57Database(Configuration configuration, JdbcConnectionFactory jdbcConnectionFactory, StatementInterceptor statementInterceptor, MySQLDatabase delegateDatabase) {
+        super(configuration, jdbcConnectionFactory, statementInterceptor);
+        this.delegateDatabase = delegateDatabase;
+    }
+
+    @Override
+    public String getRawCreateScript(Table table, boolean baseline) {
+        return delegateDatabase.getRawCreateScript(table, baseline);
+    }
+
+    @Override
+    protected MySQLConnection doGetConnection(Connection connection) {
+        return delegateDatabase.doGetConnection(connection);
+    }
+
+    @Override
+    protected MigrationVersion determineVersion() {
+        return delegateDatabase.determineVersion();
+    }
+
+    @Override
+    public final void ensureSupported() {
+        ensureDatabaseIsRecentEnough("5.1");
+        if (databaseType instanceof MariaDBDatabaseType) {
+            ensureDatabaseNotOlderThanOtherwiseRecommendUpgradeToFlywayEdition("10.4", org.flywaydb.core.internal.license.Edition.ENTERPRISE);
+            recommendFlywayUpgradeIfNecessary("10.6");
+        } else {
+            ensureDatabaseNotOlderThanOtherwiseRecommendUpgradeToFlywayEdition("5.7", org.flywaydb.core.internal.license.Edition.ENTERPRISE);
+            recommendFlywayUpgradeIfNecessary("8.0");
+        }
+    }
+
+    @Override
+    public void close() {
+        try {
+            super.close();
+        } finally {
+            delegateDatabase.close();
+        }
+    }
+
+    @Override
+    protected String doGetCurrentUser() throws SQLException {
+        return delegateDatabase.doGetCurrentUser();
+    }
+
+    @Override
+    public boolean supportsDdlTransactions() {
+        return delegateDatabase.supportsDdlTransactions();
+    }
+
+    @Override
+    public boolean supportsChangingCurrentSchema() {
+        return delegateDatabase.supportsChangingCurrentSchema();
+    }
+
+    @Override
+    public String getBooleanTrue() {
+        return delegateDatabase.getBooleanTrue();
+    }
+
+    @Override
+    public String getBooleanFalse() {
+        return delegateDatabase.getBooleanFalse();
+    }
+
+    @Override
+    public String getOpenQuote() {
+        return delegateDatabase.getOpenQuote();
+    }
+
+    @Override
+    public String getCloseQuote() {
+        return delegateDatabase.getCloseQuote();
+    }
+
+    @Override
+    public boolean catalogIsSchema() {
+        return delegateDatabase.catalogIsSchema();
+    }
+
+    @Override
+    public boolean useSingleConnection() {
+        return delegateDatabase.useSingleConnection();
+    }
+}

--- a/spring-cloud-dataflow-common-flyway/src/main/java/org/flywaydb/database/mysql/MySQL57DatabaseType.java
+++ b/spring-cloud-dataflow-common-flyway/src/main/java/org/flywaydb/database/mysql/MySQL57DatabaseType.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.database.mysql;
+
+import org.flywaydb.core.api.configuration.Configuration;
+import org.flywaydb.core.internal.database.base.Database;
+import org.flywaydb.core.internal.jdbc.JdbcConnectionFactory;
+import org.flywaydb.core.internal.jdbc.StatementInterceptor;
+
+public class MySQL57DatabaseType extends MySQLDatabaseType {
+
+	@Override
+	public Database createDatabase(Configuration configuration, JdbcConnectionFactory jdbcConnectionFactory, StatementInterceptor statementInterceptor) {
+		return new MySQL57Database(configuration, jdbcConnectionFactory, statementInterceptor);
+	}
+
+	@Override
+	public int getPriority() {
+		return super.getPriority() + 1;
+	}
+}

--- a/spring-cloud-dataflow-common-flyway/src/main/java/org/flywaydb/database/mysql/mariadb/MariaDB57Database.java
+++ b/spring-cloud-dataflow-common-flyway/src/main/java/org/flywaydb/database/mysql/mariadb/MariaDB57Database.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2022-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.database.mysql.mariadb;
+
+import org.flywaydb.core.api.configuration.Configuration;
+import org.flywaydb.core.internal.jdbc.JdbcConnectionFactory;
+import org.flywaydb.core.internal.jdbc.StatementInterceptor;
+import org.flywaydb.database.mysql.MySQL57Database;
+import org.flywaydb.database.mysql.mariadb.MariaDBDatabase;
+
+public class MariaDB57Database extends MySQL57Database {
+
+    public MariaDB57Database(Configuration configuration, JdbcConnectionFactory jdbcConnectionFactory, StatementInterceptor statementInterceptor) {
+        super(configuration, jdbcConnectionFactory, statementInterceptor, new MariaDBDatabase(configuration, jdbcConnectionFactory, statementInterceptor));
+    }
+}

--- a/spring-cloud-dataflow-common-flyway/src/main/java/org/flywaydb/database/mysql/mariadb/MariaDB57DatabaseType.java
+++ b/spring-cloud-dataflow-common-flyway/src/main/java/org/flywaydb/database/mysql/mariadb/MariaDB57DatabaseType.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.database.mysql.mariadb;
+
+import org.flywaydb.core.api.configuration.Configuration;
+import org.flywaydb.core.internal.database.base.Database;
+import org.flywaydb.core.internal.jdbc.JdbcConnectionFactory;
+import org.flywaydb.core.internal.jdbc.StatementInterceptor;
+
+public class MariaDB57DatabaseType extends MariaDBDatabaseType {
+
+	@Override
+	public Database createDatabase(Configuration configuration, JdbcConnectionFactory jdbcConnectionFactory, StatementInterceptor statementInterceptor) {
+		return new MariaDB57Database(configuration, jdbcConnectionFactory, statementInterceptor);
+	}
+
+	@Override
+	public int getPriority() {
+		return super.getPriority() + 2;
+	}
+}

--- a/spring-cloud-dataflow-common-flyway/src/main/resources/META-INF/services/org.flywaydb.core.extensibility.Plugin
+++ b/spring-cloud-dataflow-common-flyway/src/main/resources/META-INF/services/org.flywaydb.core.extensibility.Plugin
@@ -1,0 +1,2 @@
+org.flywaydb.database.mysql.mariadb.MariaDB57DatabaseType
+org.flywaydb.database.mysql.MySQL57DatabaseType

--- a/spring-cloud-dataflow-common-flyway/src/main/resources/org/flywaydb/database/version.txt
+++ b/spring-cloud-dataflow-common-flyway/src/main/resources/org/flywaydb/database/version.txt
@@ -1,0 +1,1 @@
+@flyway.version@


### PR DESCRIPTION
Fixes #20

The trick here is to compose the existing `MySQLDatabase` and `MariaDBDatabase` in order to modify the `ensureSupported` method. We can not use inheritance as the method is `final`. 

The other trick is that we set the priority on our new types higher than the default MySQL/MariaDB type which ensures we get queried w/ the "Can you handle this JDBC connection" first. 

I will add comment in subsequent commit to this PR.

cc: @markpollack @jvalkeal @corneil @cppwfs 

I have tested this in SCDF server against both MySQL and MariaDB.