### PR TITLE
Add support for MySQL 5/8 via MariaDB driver

### DIFF
--- a/spring-cloud-dataflow-common-flyway/pom.xml
+++ b/spring-cloud-dataflow-common-flyway/pom.xml
@@ -19,6 +19,10 @@
 
 	<dependencies>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-jdbc</artifactId>
 		</dependency>

--- a/spring-cloud-dataflow-common-flyway/src/main/java/org/springframework/cloud/dataflow/common/flyway/DatabaseDriverUtils.java
+++ b/spring-cloud-dataflow-common-flyway/src/main/java/org/springframework/cloud/dataflow/common/flyway/DatabaseDriverUtils.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.cloud.dataflow.common.flyway;
 
 import java.sql.DatabaseMetaData;

--- a/spring-cloud-dataflow-common-flyway/src/main/java/org/springframework/cloud/dataflow/common/flyway/DatabaseDriverUtils.java
+++ b/spring-cloud-dataflow-common-flyway/src/main/java/org/springframework/cloud/dataflow/common/flyway/DatabaseDriverUtils.java
@@ -1,0 +1,54 @@
+package org.springframework.cloud.dataflow.common.flyway;
+
+import java.sql.DatabaseMetaData;
+
+import javax.sql.DataSource;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.boot.jdbc.DatabaseDriver;
+import org.springframework.jdbc.support.JdbcUtils;
+import org.springframework.jdbc.support.MetaDataAccessException;
+
+/**
+ * Provides utility methods to help with {@link DatabaseDriver} related operations.
+ */
+public final class DatabaseDriverUtils {
+
+	private static final Logger LOG = LoggerFactory.getLogger(DatabaseDriverUtils.class);
+
+	private DatabaseDriverUtils() {
+	}
+
+	/**
+	 * Finds a database driver suitable for a datasource.
+	 * <p>By default, the jdbc url reported from the database metdata is used to determine
+	 * the driver. It also handles the special case where MariaDB reports a 'jdbc:maria'
+	 * url eventhough the original url was prefixed with 'jdbc:mysql'.
+	 *
+	 * @param dataSource the datasource to inspect
+	 * @return a database driver suitable for the datasource
+	 */
+	public static DatabaseDriver getDatabaseDriver(DataSource dataSource) {
+		// copied from boot's flyway auto-config to get matching db vendor id (but adjusted
+		// to handle the case when MariaDB driver is being used against MySQL database).
+		try {
+			String url = JdbcUtils.extractDatabaseMetaData(dataSource, DatabaseMetaData::getURL);
+			DatabaseDriver databaseDriver = DatabaseDriver.fromJdbcUrl(url);
+			if (databaseDriver == DatabaseDriver.MARIADB) {
+				// MariaDB reports a 'jdbc:maria' url even when user specified 'jdbc:mysql'.
+				// Verify the underlying database is not really MySql.
+				String product = JdbcUtils.extractDatabaseMetaData(dataSource, DatabaseMetaData::getDatabaseProductName);
+				if (DatabaseDriver.MYSQL.name().equalsIgnoreCase(product)) {
+					LOG.info("Using MariaDB driver against MySQL database - will use MySQL");
+					databaseDriver = DatabaseDriver.MYSQL;
+				}
+			}
+			return databaseDriver;
+		}
+		catch (MetaDataAccessException ex) {
+			throw new IllegalStateException(ex);
+		}
+	}
+}

--- a/spring-cloud-dataflow-common-flyway/src/main/java/org/springframework/cloud/dataflow/common/flyway/FlywayVendorReplacingEnvironmentPostProcessor.java
+++ b/spring-cloud-dataflow-common-flyway/src/main/java/org/springframework/cloud/dataflow/common/flyway/FlywayVendorReplacingEnvironmentPostProcessor.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2022-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.common.flyway;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.env.EnvironmentPostProcessor;
+import org.springframework.core.Ordered;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
+
+/**
+ * An {@link EnvironmentPostProcessor} that replaces any configured 'spring.flyways.locations'
+ * properties that contain the '{vendor}' token with 'mysql' when using the MariaDB driver
+ * to access a MySQL database.
+ *
+ * @author Chris Bono
+ */
+public class FlywayVendorReplacingEnvironmentPostProcessor implements EnvironmentPostProcessor, Ordered {
+
+	private final Logger log = LoggerFactory.getLogger(FlywayVendorReplacingEnvironmentPostProcessor.class);
+
+	@Override
+	public void postProcessEnvironment(ConfigurableEnvironment env, SpringApplication app) {
+
+		// If there is a spring.datasource.url prefixed w/ "jdbc:mysql:" and using the MariaDB driver then replace {vendor}
+		boolean usingMariaDriver = env.getProperty("spring.datasource.driver-class-name", "").equals("org.mariadb.jdbc.Driver");
+		boolean usingMySqlUrl = env.getProperty("spring.datasource.url", "").startsWith("jdbc:mysql:");
+		if (!(usingMariaDriver && usingMySqlUrl)) {
+			return;
+		}
+
+		log.info("Using MariaDB driver w/ MySQL url - looking for '{vendor}' in 'spring.flyway.locations'");
+
+		// Look for spring.flyway.locations[0..N] and if found then override it w/ vendor replaced version
+		Map<String, Object> replacedLocations = new HashMap<>();
+
+		int prodIdx = 0;
+		while (true) {
+			String locationPropName = String.format("spring.flyway.locations[%d]", prodIdx++);
+			String configuredLocation = env.getProperty(locationPropName);
+			if (configuredLocation == null) {
+				break;
+			}
+			if (configuredLocation.contains("{vendor}")) {
+				String replaceLocation = configuredLocation.replace("{vendor}", "mysql");
+				replacedLocations.put(locationPropName, replaceLocation);
+			}
+		}
+
+		if (replacedLocations.isEmpty()) {
+			log.info("No properties with '{vendor}' found to replace");
+			return;
+		}
+
+		log.info("Replacing '{vendor}' in {}", replacedLocations);
+
+		env.getPropertySources().addFirst(new MapPropertySource("overrideVendorInFlywayLocations", replacedLocations));
+	}
+
+	/**
+	 * The precedence for execution order - should execute last.
+	 *
+	 * @return lowest precedence to ensure it executes after other post processors
+	 */
+	@Override
+	public int getOrder() {
+		return 100;
+	}
+}

--- a/spring-cloud-dataflow-common-flyway/src/test/java/org/springframework/cloud/dataflow/common/flyway/FlywayVendorReplacingEnvironmentPostProcessorTests.java
+++ b/spring-cloud-dataflow-common-flyway/src/test/java/org/springframework/cloud/dataflow/common/flyway/FlywayVendorReplacingEnvironmentPostProcessorTests.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2022-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.common.flyway;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.core.env.ConfigurableEnvironment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for {@link FlywayVendorReplacingEnvironmentPostProcessor}.
+ */
+public class FlywayVendorReplacingEnvironmentPostProcessorTests {
+
+	@ParameterizedTest(name = "{0}")
+	@MethodSource("vendorReplacedProperlyProvider")
+	void vendorReplacedProperly(boolean usingMySqlUrl, boolean usingMariaDriver, List<String> configuredLocationProps, List<String> finalLocationProps) {
+		List<String> props = new ArrayList<>();
+		props.add("spring.datasource.url=" + (usingMySqlUrl ? "jdbc:mysql://localhost:3306/dataflow?permitMysqlScheme" : "jdbc:mariadb://localhost:3306/dataflow"));
+		props.add("spring.datasource.driver-class-name=" + (usingMariaDriver ? "org.mariadb.jdbc.Driver" : "org.mysql.jdbc.Driver"));
+		props.addAll(configuredLocationProps);
+
+		// Prime an actual env by running it through the AppContextRunner with the configured properties
+		new ApplicationContextRunner().withPropertyValues(props.toArray(new String[0])).run((context) -> {
+			ConfigurableEnvironment env = context.getEnvironment();
+
+			// Sanity check the locations props are as expected
+			configuredLocationProps.forEach((location) -> {
+				String key = location.split("=")[0];
+				String value = location.split("=")[1];
+				assertThat(env.getProperty(key)).isEqualTo(value);
+			});
+
+			// Run the env through the EPP
+			FlywayVendorReplacingEnvironmentPostProcessor epp = new FlywayVendorReplacingEnvironmentPostProcessor();
+			epp.postProcessEnvironment(env, mock(SpringApplication.class));
+
+			// Verify they are replaced as expected
+			finalLocationProps.forEach((location) -> {
+				String key = location.split("=")[0];
+				String value = location.split("=")[1];
+				assertThat(env.getProperty(key)).isEqualTo(value);
+			});
+		});
+	}
+
+	private static Stream<Arguments> vendorReplacedProperlyProvider() {
+		return Stream.of(
+				arguments(Named.of("singleLocationWithVendor",true), true,
+						Collections.singletonList("spring.flyway.locations[0]=classpath:org/skipper/db/{vendor}"),
+						Collections.singletonList("spring.flyway.locations[0]=classpath:org/skipper/db/mysql")
+				),
+				arguments(Named.of("singleLocationWithoutVendor",true), true,
+						Collections.singletonList("spring.flyway.locations[0]=classpath:org/skipper/db/foo"),
+						Collections.singletonList("spring.flyway.locations[0]=classpath:org/skipper/db/foo")
+				),
+				arguments(Named.of("noLocations",true), true,
+						Collections.emptyList(),
+						Collections.emptyList()
+				),
+				arguments(Named.of("multiLocationsAllWithVendor",true), true,
+						Arrays.asList(
+								"spring.flyway.locations[0]=classpath:org/skipper/db0/{vendor}",
+								"spring.flyway.locations[1]=classpath:org/skipper/db1/{vendor}",
+								"spring.flyway.locations[2]=classpath:org/skipper/db2/{vendor}"),
+						Arrays.asList(
+								"spring.flyway.locations[0]=classpath:org/skipper/db0/mysql",
+								"spring.flyway.locations[1]=classpath:org/skipper/db1/mysql",
+								"spring.flyway.locations[2]=classpath:org/skipper/db2/mysql")
+				),
+				arguments(Named.of("multiLocationsSomeWithVendor",true), true,
+						Arrays.asList(
+								"spring.flyway.locations[0]=classpath:org/skipper/db0/{vendor}",
+								"spring.flyway.locations[1]=classpath:org/skipper/db1/foo",
+								"spring.flyway.locations[2]=classpath:org/skipper/db2/{vendor}"),
+						Arrays.asList(
+								"spring.flyway.locations[0]=classpath:org/skipper/db0/mysql",
+								"spring.flyway.locations[1]=classpath:org/skipper/db1/foo",
+								"spring.flyway.locations[2]=classpath:org/skipper/db2/mysql")
+				),
+				arguments(Named.of("multiLocationsNoneWithVendor",true), true,
+						Arrays.asList(
+								"spring.flyway.locations[0]=classpath:org/skipper/db0/foo",
+								"spring.flyway.locations[1]=classpath:org/skipper/db1/bar",
+								"spring.flyway.locations[2]=classpath:org/skipper/db2/zaa"),
+						Arrays.asList(
+								"spring.flyway.locations[0]=classpath:org/skipper/db0/foo",
+								"spring.flyway.locations[1]=classpath:org/skipper/db1/bar",
+								"spring.flyway.locations[2]=classpath:org/skipper/db2/zaa")
+				),
+				arguments(Named.of("mariaUrlWithMariaDriverDoesNotReplace",false), true,
+						Collections.singletonList("spring.flyway.locations[0]=classpath:org/skipper/db/{vendor}"),
+						Collections.singletonList("spring.flyway.locations[0]=classpath:org/skipper/db/{vendor}")
+				),
+				arguments(Named.of("mysqlUrlWithMysqlDriverDoesNotReplace",true), false,
+						Collections.singletonList("spring.flyway.locations[0]=classpath:org/skipper/db/{vendor}"),
+						Collections.singletonList("spring.flyway.locations[0]=classpath:org/skipper/db/{vendor}")
+				),
+				arguments(Named.of("mariaUrlMysqlDriverDoesNotReplace",false), false,
+						Collections.singletonList("spring.flyway.locations[0]=classpath:org/skipper/db/{vendor}"),
+						Collections.singletonList("spring.flyway.locations[0]=classpath:org/skipper/db/{vendor}")
+				)
+		);
+	}
+}


### PR DESCRIPTION
This PR provides the following:

* **WHAT** An `EnvironmentPostProcessor` that will replace the `{vendor}` token in any `spring.flyway.locations` entries.
  * **WHY** SpringBoot FlywayAutoConfiguration will replace the `{vendor}` token w/ `mariadb` when using the mariadb driver to talk to mysql db. Long term this should be fixed in SB. I will file an issue in SB once the dust settles here. 
  * **WHERE**  consumed in Dataflow and Skipper and there is an integration test in ~each~dataflow to verify this is doing what its supposed to. 

* **WHAT** a utility class to properly return a database driver given a datasource.
  * **WHY** the mechanism in Boot uses jdbc url from the database metadata which incorrectly reports MariaDB when using a MariaDB driver against a MySQL DB.
  * **WHERE** consumed in Dataflow and Skipper flyway callback customizer to ensure it picks proper baseline callback scripts


See https://github.com/spring-cloud/spring-cloud-dataflow/issues/4887